### PR TITLE
Improve validation result type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,15 @@ import { ajv as ajvInternal } from './utils/validation';
 
 import { ErrorObject, JSONSchemaType, KeywordDefinition, SchemaObject } from 'ajv';
 import { useDebounce } from './Hooks/useDebounce';
-import { AJVMessageFunction, FormField, IState, UseFormReturn } from './utils/types';
+import {
+  AJVMessageFunction,
+  FormField,
+  IState,
+  UseFormReturn,
+  ValidateResult,
+} from './utils/types';
 import Logger from './utils/Logger';
+
 const useAJVForm = <T extends Record<string, any>>(
   initial: T,
   schema: JSONSchemaType<T> | SchemaObject,
@@ -114,7 +121,7 @@ const useAJVForm = <T extends Record<string, any>>(
     });
   };
 
-  const validateForm = () => {
+  const validateForm = (): ValidateResult<T> => {
     const data = Object.keys(state).reduce((acc, inputName) => {
       acc[inputName as keyof T] = getValue(state[inputName].value) as T[keyof T];
       return acc;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -42,15 +42,21 @@ export type InitialState<T> = {
   };
 };
 
-export type ValidateResult<T> = {
-  isValid: boolean;
-  data: T | null;
-  errors?: Partial<{ [K in keyof T]: T[K] }>;
-};
+export type ValidateResult<T> =
+  | {
+      isValid: true;
+      data: T;
+    }
+  | {
+      isValid: false;
+      data: null;
+      errors?: Partial<{ [K in keyof T]: T[K] }>;
+    };
 
 export type useFormErrors<T> = {
   [K in keyof T]?: string;
 };
+
 export interface UseFormReturn<T> {
   data: T;
   state: IState<T>;


### PR DESCRIPTION
A small improvement to the validation type so one can do

```ts
    const { data, isValid } = form.validate();

    if (!isValid) {
      return;
    }
 
   // `data` is now inferred to be non-null
```